### PR TITLE
chore: upgrade to 0.6 Ape

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,11 +1,12 @@
 ---
 name: Bug report
 about: Report an error that you've encountered.
-labels: 'bug'
+labels: bug
 ---
+
 ### Environment information
 
-* `ape` and plugin versions:
+- `ape` and plugin versions:
 
 ```
 $ ape --version
@@ -15,16 +16,16 @@ $ ape plugins list
 # ...copy and paste result of above command here...
 ```
 
-* Python Version: x.x.x
-* OS: osx/linux/win
+- Python Version: x.x.x
+- OS: macOS/linux/win
 
 ### What went wrong?
 
 Please include information like:
 
-* what command you ran
-* the code that caused the failure (see [this link](https://help.github.com/articles/basic-writing-and-formatting-syntax/) for help with formatting code)
-* full output of the error you received
+- what command you ran
+- the code that caused the failure (see [this link](https://help.github.com/articles/basic-writing-and-formatting-syntax/) for help with formatting code)
+- full output of the error you received
 
 ### How can it be fixed?
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,15 +1,15 @@
 ---
 name: Feature request
 about: Request a new feature, or an improvement to existing functionality.
-labels: 'enhancement'
+labels: enhancement
 ---
 
 ### Overview
 
 Provide a simple overview of what you wish to see added. Please include:
 
-* What you are trying to do
-* Why Ape's current functionality is inadequate to address your goal
+- What you are trying to do
+- Why Ape's current functionality is inadequate to address your goal
 
 ### Specification
 

--- a/.github/ISSUE_TEMPLATE/work-item.md
+++ b/.github/ISSUE_TEMPLATE/work-item.md
@@ -1,14 +1,15 @@
 ---
 name: Work item
 about: New work item for Ape team
-labels: 'backlog'
-
+labels: backlog
 ---
 
 ### Elevator pitch:
+
 <!-- 1-2 line summary of the scope of this work item -->
 
 ### Value:
+
 <!--
   Who is this for?
   Persona or group of people whom will derive value from the scenario.
@@ -16,26 +17,32 @@ labels: 'backlog'
 -->
 
 ### Dependencies:
+
 <!-- Call out key people, teams, tech dependencies, or assumptions. -->
 
 ### Design approach:
+
 <!--
   Free text / diagram / whiteboard picture / etc. that clearly shows your approach and considerations to build the task list.
   Existing code patterns in production code base that you will base your work off of.
 -->
 
 ### Task list:
+
 <!-- Bulleted list describing the exit criteria, desired end state and any documentation, monitors, work for DRI, etc. that will need to be added to make sure someone else can support once it's live. -->
-* [ ] Tasks go here
+
+- [ ] Tasks go here
 
 ### Estimated completion date:
 
-
 ### Design review:
+
 <!-- 1-2 people needed for signoff -->
+
 Do not signoff unless:
-- 1) agreed the tasks and design approach will achieve acceptance, and
-- 2) the work can be completed by one person within the SLA.
-Design reviewers should consider simpler approaches to achieve goals.
+
+- 1. agreed the tasks and design approach will achieve acceptance, and
+- 2. the work can be completed by one person within the SLA.
+     Design reviewers should consider simpler approaches to achieve goals.
 
 (Please leave a comment to sign off)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,7 @@
 ### What I did
 
 <!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
+
 fixes: #
 
 ### How I did it

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -31,7 +31,7 @@ version-resolver:
 
 template: |
   ## Changes
-  
+
   $CHANGES
-  
+
   Special thanks to: $CONTRIBUTORS

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -9,17 +9,17 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
               fetch-depth: 0
 
         - name: Setup Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v4
           with:
               python-version: 3.8
 
         - name: Install Dependencies
-          run: pip install .[dev]
+          run: pip install commitizen
 
         - name: Check commit history
           run: cz check --rev-range $(git rev-list --all --reverse | head -1)..HEAD

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
 
@@ -21,7 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[release]
-        
+
     - name: Build
       run: python setup.py sdist bdist_wheel
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,69 +2,82 @@ on: ["push", "pull_request"]
 
 name: Test
 
+concurrency:
+  # Cancel older, in-progress jobs from the same PR, same workflow.
+  # use run_id if the job is triggered by a push to ensure
+  # push-triggered jobs to not get canceled.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
-    linting:
-        runs-on: ubuntu-latest
+  linting:
+    runs-on: ubuntu-latest
 
-        steps:
-        - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v3
 
-        - name: Setup Python
-          uses: actions/setup-python@v2
-          with:
-              python-version: 3.8
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
 
-        - name: Install Dependencies
-          run: pip install .[lint]
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[lint]
 
-        - name: Run Black
-          run: black --check .
+      - name: Run Black
+        run: black --check .
 
-        - name: Run flake8
-          run: flake8 .
+      - name: Run isort
+        run: isort --check-only .
 
-        - name: Run isort
-          run: isort --check-only .
+      - name: Run flake8
+        run: flake8 .
 
-    type-check:
-        runs-on: ubuntu-latest
+      - name: Run mdformat
+        run: mdformat . --check
 
-        steps:
-        - uses: actions/checkout@v2
+  type-check:
+    runs-on: ubuntu-latest
 
-        - name: Setup Python
-          uses: actions/setup-python@v2
-          with:
-              python-version: 3.8
+    steps:
+      - uses: actions/checkout@v3
 
-        - name: Install Dependencies
-          run: pip install .[lint,test]  # Might need test deps
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8
 
-        - name: Run MyPy
-          run: mypy .
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[lint,test]
 
-    functional:
-        runs-on: ${{ matrix.os }}
+      - name: Run MyPy
+        run: mypy .
 
-        strategy:
-            matrix:
-                os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
-                python-version: [3.8, 3.9, '3.10']
+  functional:
+    runs-on: ${{ matrix.os }}
 
-        steps:
-        - uses: actions/checkout@v2
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest] # eventually add `windows-latest`
+        python-version: [3.8, 3.9, "3.10"]
 
-        - name: Setup Python
-          uses: actions/setup-python@v2
-          with:
-              python-version: ${{ matrix.python-version }}
+    steps:
+      - uses: actions/checkout@v3
 
-        - name: Install Dependencies
-          run: pip install .[test]
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-        - name: Run Tests
-          run: pytest -m "not fuzzing" -n 0 -s --cov
+      - name: Install Dependencies
+        run: pip install .[test]
 
+      - name: Run Tests
+        run: pytest -m "not fork and not manual and not fuzzing"
 # NOTE: uncomment this block after you've marked tests with @pytest.mark.fuzzing
 #    fuzzing:
 #        runs-on: ubuntu-latest
@@ -73,10 +86,10 @@ jobs:
 #            fail-fast: true
 #
 #        steps:
-#        - uses: actions/checkout@v2
+#        - uses: actions/checkout@v3
 #
 #        - name: Setup Python
-#          uses: actions/setup-python@v2
+#          uses: actions/setup-python@v4
 #          with:
 #              python-version: 3.8
 #

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.build/
 build/
 develop-eggs/
 dist/
@@ -117,5 +118,14 @@ dmypy.json
 # setuptools-scm
 version.py
 
+# NPM
+package.json
+package-lock.json
+node_modules/
+
 # Ape stuff
 .build/
+
+**/.DS_Store
+*.swp
+*.swo

--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,0 +1,1 @@
+number = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,30 +1,36 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0
     hooks:
-    -   id: check-yaml
+      - id: check-yaml
 
--   repo: https://github.com/pre-commit/mirrors-isort
+  - repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.10.1
     hooks:
       - id: isort
 
--   repo: https://github.com/psf/black
-    rev: 22.6.0
+  - repo: https://github.com/psf/black
+    rev: 22.12.0
     hooks:
       - id: black
         name: black
 
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
-    -   id: flake8
+      - id: flake8
 
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.991
     hooks:
-    -   id: mypy
-        additional_dependencies: [types-requests]
+      - id: mypy
+        additional_dependencies: [types-setuptools, pydantic]
+
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.14
+    hooks:
+      - id: mdformat
+        additional_dependencies: [mdformat-gfm, mdformat-frontmatter]
 
 default_language_version:
-    python: python3
+  python: python3

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Instantiate a Jupyter Notebook with Ape!
 
 ## Dependencies
 
-* [python3](https://www.python.org/downloads) version 3.7 or greater, python3-dev
+- [python3](https://www.python.org/downloads) version 3.8 or greater, python3-dev
 
 ## Installation
 
@@ -27,8 +27,6 @@ python3 setup.py install
 ```
 
 ## Quick Usage
-
-
 
 ## Development
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     install_requires=[
         "notebook>=6.5.2",
         "click>=8.1.3",
-        "eth-ape>=0.5.8,<0.6.0",
+        "eth-ape>=0.6.0,<0.7",
     ],
     entry_points={
         "ape_cli_subcommands": [


### PR DESCRIPTION
### What I did

Upgrade plugin to ape v0.6

### How I did it
cribbing off PRs in [ape-foundry](https://github.com/ApeWorX/ape-foundry/pull/29) [ape-solidity](https://github.com/ApeWorX/ape-solidity/pull/87) and [ape-etherscan](https://github.com/ApeWorX/ape-etherscan/pull/69)

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
