### PR TITLE
fix: setup.py for notebook<7 [APE-1310]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     url="https://github.com/ApeWorX/ape-notebook",
     include_package_data=True,
     install_requires=[
-        "notebook>=6.5.2",
+        "notebook>=6.5.4,<7",
         "click>=8.1.3",
         "eth-ape>=0.6.0,<0.7",
     ],


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #8 

### How I did it

```py
install_requires=[
   "notebook>=6.5.2,<7",
   ...
]
```

### How to verify it

```sh
$ ape notebook
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
