### PR TITLE
feat: support notebook>=7,<8 [APE-1313]

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,17 @@ python3 setup.py install
 ## Quick Usage
 
 Runs a notebook server:
-`ape notebook`
+
+```bash
+ape notebook
+```
+
+`notebook >=7` has an outstanding issue at launch that can be [resolved](https://github.com/jupyter/notebook/issues/6974#issuecomment-1675394990)
+by running in your environment
+
+```bash
+jupyter lab build
+```
 
 ## Development
 

--- a/ape_notebook/_cli.py
+++ b/ape_notebook/_cli.py
@@ -1,5 +1,5 @@
 import click
-from notebook.notebookapp import launch_new_instance  # type: ignore
+from notebook.app import launch_new_instance  # type: ignore
 
 
 # %%

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     url="https://github.com/ApeWorX/ape-notebook",
     include_package_data=True,
     install_requires=[
-        "notebook>=6.5.4,<7",
+        "notebook>=7.0.0,<8",
         "click>=8.1.3",
         "eth-ape>=0.6.0,<0.7",
     ],


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

Added support for Jupyter Notebook 7

### How I did it

In `ape_notebook/_cli.py`:

```py
from notebook.app import launch_new_instance
```

plus modified `setup.py` to require `notebook>=7.0.0,<8`

### How to verify it

```sh
jupyter lab build
ape notebook
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
